### PR TITLE
[feature]  비밀번호 암호화, 토큰 재발급 개발 완료

### DIFF
--- a/user-service/src/main/java/com/mockcote/user/controller/AuthController.java
+++ b/user-service/src/main/java/com/mockcote/user/controller/AuthController.java
@@ -1,13 +1,17 @@
 package com.mockcote.user.controller;
 
+import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.catalina.connector.Response;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,7 +19,9 @@ import com.mockcote.user.dto.LoginRequest;
 import com.mockcote.user.service.UserService;
 import com.mockcote.user.util.JwtUtil;
 
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
@@ -36,7 +42,7 @@ public class AuthController {
             // UserService로 로그인 검증
         	Map<String, String> tokens = userService.login(loginRequest);
         	
-        	Cookie refreshTokenCookie = new Cookie("refreshToken",tokens.get("refreshToken"));
+        	Cookie refreshTokenCookie = new Cookie("refreshToken", tokens.get("refreshToken"));
         	refreshTokenCookie.setHttpOnly(true); // JavaScript 접근 금지
     	    refreshTokenCookie.setSecure(true); // HTTPS에서만 전송 (HTTPS 환경에서 설정)
     	    refreshTokenCookie.setPath("/"); // 모든 경로에서 쿠키 사용 가능
@@ -70,4 +76,27 @@ public class AuthController {
 
 	    return ResponseEntity.ok("로그아웃이 완료되었습니다.");
 	}
+    
+    @GetMapping("/refresh")
+    public ResponseEntity<?> refresh(@CookieValue(value = "refreshToken") String refreshToken) {
+    	if(refreshToken == null) {
+    		return ResponseEntity.status(401).body("No Refresh Token found");
+    	}
+    	
+    	if(jwtUtil.validateRefreshToken(refreshToken)) {
+    		Map<String, Object> response = new HashMap<>();
+    		
+    		Claims claim = jwtUtil.getClaimFromRefreshToken(refreshToken);
+    		String userId = (String) claim.get("userId");
+    		String handle = claim.getSubject();
+    		
+    		String accessToken = jwtUtil.generateToken(userId, handle);
+    		response.put("accessToken", accessToken);
+    		
+    		System.out.println("토큰 재발급");
+    		return ResponseEntity.ok(response);
+    	} else {
+    		return ResponseEntity.status(401).body("invalid refresh token");
+    	}
+    }
 }

--- a/user-service/src/main/java/com/mockcote/user/controller/AuthController.java
+++ b/user-service/src/main/java/com/mockcote/user/controller/AuthController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.mockcote.user.dto.LoginRequest;
-import com.mockcote.user.service.UserService;
+import com.mockcote.user.service.UserServiceImpl;
 import com.mockcote.user.util.JwtUtil;
 
 import io.jsonwebtoken.Claims;
@@ -30,7 +30,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AuthController {
 	
-	private final UserService userService;
+	private final UserServiceImpl userService;
 	
     @Autowired
     private JwtUtil jwtUtil;

--- a/user-service/src/main/java/com/mockcote/user/controller/UserController.java
+++ b/user-service/src/main/java/com/mockcote/user/controller/UserController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.mockcote.user.dto.JoinRequest;
 import com.mockcote.user.dto.User;
-import com.mockcote.user.service.UserService;
+import com.mockcote.user.service.UserServiceImpl;
 import com.mockcote.user.util.JwtUtil;
 
 import io.jsonwebtoken.Claims;
@@ -31,7 +31,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class UserController {
 	
-	private final UserService userService;
+	private final UserServiceImpl userService;
 	
 	private final JwtUtil jwtUtil;
 	

--- a/user-service/src/main/java/com/mockcote/user/controller/UserController.java
+++ b/user-service/src/main/java/com/mockcote/user/controller/UserController.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,7 +20,9 @@ import org.springframework.web.bind.annotation.RestController;
 import com.mockcote.user.dto.JoinRequest;
 import com.mockcote.user.dto.User;
 import com.mockcote.user.service.UserService;
+import com.mockcote.user.util.JwtUtil;
 
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 
@@ -29,6 +32,8 @@ import lombok.RequiredArgsConstructor;
 public class UserController {
 	
 	private final UserService userService;
+	
+	private final JwtUtil jwtUtil;
 	
     @GetMapping("/hello")
     public String hello(@RequestHeader(value = "X-Authenticated-User", required = false) String username,
@@ -111,8 +116,5 @@ public class UserController {
             return ResponseEntity.badRequest().body("No matching user found for handle: " + handle);
         }
     }
-    
-    
-    
     
 }

--- a/user-service/src/main/java/com/mockcote/user/service/UserService.java
+++ b/user-service/src/main/java/com/mockcote/user/service/UserService.java
@@ -1,133 +1,21 @@
 package com.mockcote.user.service;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
 import com.mockcote.user.dto.JoinRequest;
 import com.mockcote.user.dto.LoginRequest;
 import com.mockcote.user.dto.User;
-import com.mockcote.user.entity.UserEntity;
-import com.mockcote.user.repository.UserRepository;
-import com.mockcote.user.util.JwtUtil;
-import com.mockcote.user.util.PasswordEncryptionUtil;
 
-import jakarta.transaction.Transactional;
-import lombok.RequiredArgsConstructor;
-
-@Service
-@RequiredArgsConstructor
-public class UserService {
-
-	private final UserRepository userRepo;
+public interface UserService {
+	public int join(JoinRequest join);
 	
-	@Autowired
-    private JwtUtil jwtUtil;
+	public List<User> selectAll();
+	public User selectUser(String handle);
 	
-	@Transactional
-	public int join(JoinRequest join) {
-		try {
-			String endcodedPw = PasswordEncryptionUtil.encryptPassword(join.getPw());
-			UserEntity user = new UserEntity(join.getUserId(), endcodedPw, join.getHandle());
-			
-			UserEntity result = userRepo.save(user);
-			
-			System.out.println("Join Entity: " + result);
-			return 1;
-		} catch (Exception e) {
-			e.printStackTrace();
-			return 0;
-		}
-	}
+	public Map<String, String> login(LoginRequest loginRequest);
 	
-	public List<User> selectAll() {
-		List<User> list = userRepo.findAllUser();
-		
-		return list;
-	}
-	
-	public User selectUser(String handle) {
-		User user = userRepo.findUser(handle);
-		
-		return user;
-	}
-	
-	@Transactional
-	public Map<String, String> login(LoginRequest loginRequest) {
-		
-		String userId = loginRequest.getUserId();
-		String rawPassword = loginRequest.getPassword();
-		
-        // DB에서 사용자 조회
-        UserEntity userEntity = userRepo.findByUserId(userId)
-                .orElseThrow(() -> new IllegalArgumentException("Invalid userId or password"));
-
-        // 비밀번호 검증
-        if (!PasswordEncryptionUtil.isPasswordMatch(rawPassword, userEntity.getPw())) {
-            throw new IllegalArgumentException("Invalid userId or password");
-        }
-        
-        // 로그인 성공 토큰 생성
-        Map<String, String> tokens = new HashMap<>();
-        String handle = userEntity.getHandle();
-        String accessToken = jwtUtil.generateToken(userId,handle);
-        String refreshToken = jwtUtil.generateRefreshToken(userId,handle);
-        
-        // refreshtoken DB에 저장
-        userRepo.updateRefreshToken(userId, refreshToken);
-        
-        tokens.put("accessToken", accessToken);
-        tokens.put("refreshToken", refreshToken);
-        tokens.put("handle", handle);
-        return tokens;
-    }
-	
-	
-	@Transactional
-    public int updateUserPassword(String handle, String rawPassword) {
-        // 유효성 검사
-        if (handle == null || handle.isEmpty() || rawPassword == null || rawPassword.isEmpty()) {
-            throw new IllegalArgumentException("Handle and password must not be null or empty.");
-        }
-
-        // 비밀번호 암호화
-        String encryptedPassword = PasswordEncryptionUtil.encryptPassword(rawPassword);
-
-        // 업데이트 작업
-        int updatedRows = userRepo.updatePasswordByIdAndHandle(handle, encryptedPassword);
-
-        // 결과 처리
-        if (updatedRows > 0) {
-            System.out.println("Password updated successfully for handle: " + handle);
-            return updatedRows;
-        } else {
-            System.out.println("No matching user found for handle: " + handle);
-            return 0;
-        }
-    }
-	
-	@Transactional
-    public int deleteUserByHandle(String handle) {
-        // 삭제 작업 수행
-        int deletedRows = userRepo.deleteUserByHandle(handle);
-
-        // 삭제된 레코드가 없으면 예외 발생
-        if (deletedRows == 0) {
-            throw new IllegalArgumentException("No user found with handle: " + handle);
-        }
-
-        // 성공 메시지 출력
-        System.out.println("User with handle " + handle + " deleted successfully.");
-        return deletedRows; // 삭제된 행의 수 반환
-    }
-
-	@Transactional
-	public void deleteRefreshToken(String refreshToken) {
-		userRepo.deleteRefreshToken(refreshToken);
-		
-	}
-
+	public int updateUserPassword(String handle, String rawPassword);
+	public int deleteUserByHandle(String handle);
+	public void deleteRefreshToken(String refreshToken);
 }

--- a/user-service/src/main/java/com/mockcote/user/service/UserService.java
+++ b/user-service/src/main/java/com/mockcote/user/service/UserService.java
@@ -30,7 +30,8 @@ public class UserService {
 	@Transactional
 	public int join(JoinRequest join) {
 		try {
-			UserEntity user = new UserEntity(join.getUserId(), join.getPw(), join.getHandle());
+			String endcodedPw = PasswordEncryptionUtil.encryptPassword(join.getPw());
+			UserEntity user = new UserEntity(join.getUserId(), endcodedPw, join.getHandle());
 			
 			UserEntity result = userRepo.save(user);
 			
@@ -64,10 +65,10 @@ public class UserService {
         UserEntity userEntity = userRepo.findByUserId(userId)
                 .orElseThrow(() -> new IllegalArgumentException("Invalid userId or password"));
 
-//        // 비밀번호 검증
-//        if (!PasswordEncryptionUtil.isPasswordMatch(rawPassword, userEntity.getPw())) {
-//            throw new IllegalArgumentException("Invalid userId or password");
-//        }
+        // 비밀번호 검증
+        if (!PasswordEncryptionUtil.isPasswordMatch(rawPassword, userEntity.getPw())) {
+            throw new IllegalArgumentException("Invalid userId or password");
+        }
         
         // 로그인 성공 토큰 생성
         Map<String, String> tokens = new HashMap<>();

--- a/user-service/src/main/java/com/mockcote/user/service/UserServiceImpl.java
+++ b/user-service/src/main/java/com/mockcote/user/service/UserServiceImpl.java
@@ -1,0 +1,133 @@
+package com.mockcote.user.service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.mockcote.user.dto.JoinRequest;
+import com.mockcote.user.dto.LoginRequest;
+import com.mockcote.user.dto.User;
+import com.mockcote.user.entity.UserEntity;
+import com.mockcote.user.repository.UserRepository;
+import com.mockcote.user.util.JwtUtil;
+import com.mockcote.user.util.PasswordEncryptionUtil;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+	private final UserRepository userRepo;
+	
+	@Autowired
+    private JwtUtil jwtUtil;
+	
+	@Transactional
+	public int join(JoinRequest join) {
+		try {
+			String endcodedPw = PasswordEncryptionUtil.encryptPassword(join.getPw());
+			UserEntity user = new UserEntity(join.getUserId(), endcodedPw, join.getHandle());
+			
+			UserEntity result = userRepo.save(user);
+			
+			System.out.println("Join Entity: " + result);
+			return 1;
+		} catch (Exception e) {
+			e.printStackTrace();
+			return 0;
+		}
+	}
+	
+	public List<User> selectAll() {
+		List<User> list = userRepo.findAllUser();
+		
+		return list;
+	}
+	
+	public User selectUser(String handle) {
+		User user = userRepo.findUser(handle);
+		
+		return user;
+	}
+	
+	@Transactional
+	public Map<String, String> login(LoginRequest loginRequest) {
+		
+		String userId = loginRequest.getUserId();
+		String rawPassword = loginRequest.getPassword();
+		
+        // DB에서 사용자 조회
+        UserEntity userEntity = userRepo.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid userId or password"));
+
+        // 비밀번호 검증
+        if (!PasswordEncryptionUtil.isPasswordMatch(rawPassword, userEntity.getPw())) {
+            throw new IllegalArgumentException("Invalid userId or password");
+        }
+        
+        // 로그인 성공 토큰 생성
+        Map<String, String> tokens = new HashMap<>();
+        String handle = userEntity.getHandle();
+        String accessToken = jwtUtil.generateToken(userId,handle);
+        String refreshToken = jwtUtil.generateRefreshToken(userId,handle);
+        
+        // refreshtoken DB에 저장
+        userRepo.updateRefreshToken(userId, refreshToken);
+        
+        tokens.put("accessToken", accessToken);
+        tokens.put("refreshToken", refreshToken);
+        tokens.put("handle", handle);
+        return tokens;
+    }
+	
+	
+	@Transactional
+    public int updateUserPassword(String handle, String rawPassword) {
+        // 유효성 검사
+        if (handle == null || handle.isEmpty() || rawPassword == null || rawPassword.isEmpty()) {
+            throw new IllegalArgumentException("Handle and password must not be null or empty.");
+        }
+
+        // 비밀번호 암호화
+        String encryptedPassword = PasswordEncryptionUtil.encryptPassword(rawPassword);
+
+        // 업데이트 작업
+        int updatedRows = userRepo.updatePasswordByIdAndHandle(handle, encryptedPassword);
+
+        // 결과 처리
+        if (updatedRows > 0) {
+            System.out.println("Password updated successfully for handle: " + handle);
+            return updatedRows;
+        } else {
+            System.out.println("No matching user found for handle: " + handle);
+            return 0;
+        }
+    }
+	
+	@Transactional
+    public int deleteUserByHandle(String handle) {
+        // 삭제 작업 수행
+        int deletedRows = userRepo.deleteUserByHandle(handle);
+
+        // 삭제된 레코드가 없으면 예외 발생
+        if (deletedRows == 0) {
+            throw new IllegalArgumentException("No user found with handle: " + handle);
+        }
+
+        // 성공 메시지 출력
+        System.out.println("User with handle " + handle + " deleted successfully.");
+        return deletedRows; // 삭제된 행의 수 반환
+    }
+
+	@Transactional
+	public void deleteRefreshToken(String refreshToken) {
+		userRepo.deleteRefreshToken(refreshToken);
+		
+	}
+
+}

--- a/user-service/src/main/java/com/mockcote/user/util/JwtUtil.java
+++ b/user-service/src/main/java/com/mockcote/user/util/JwtUtil.java
@@ -1,5 +1,6 @@
 package com.mockcote.user.util;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -18,7 +19,7 @@ public class JwtUtil {
 
     public JwtUtil(
             @Value("${jwt.secret}") String secret,
-            @Value("${jwt.accessExpiration:3600000}") long accessExpiration,  // 기본값: 1시간
+            @Value("${jwt.accessExpiration:60000}") long accessExpiration,  // 기본값: 1시간
             @Value("${jwt.refreshExpiration:43200000}") long refreshExpiration // 기본값: 12시간
     ) {
         this.secretKey = Base64.getDecoder().decode(secret);
@@ -53,5 +54,32 @@ public class JwtUtil {
                 .claim("type", "refresh") // 토큰 유형 구분을 위한 클레임 추가 (선택)
                 .signWith(Keys.hmacShaKeyFor(secretKey), SignatureAlgorithm.HS256)
                 .compact();
+    }
+    
+    // JWT 유효성 검증 메서드
+    public boolean validateRefreshToken(String refreshToken) {
+        try {
+            Jwts.parserBuilder() // JWT 파서 빌더 생성
+                .setSigningKey(secretKey) // 서명 검증에 사용할 키 설정
+                .build() // 파서 빌드
+                .parseClaimsJws(refreshToken); // **JWT 파싱 및 서명 검증**
+            return true; // 유효한 토큰인 경우 true 반환
+        } catch (Exception e) {
+            System.err.println("JWT validation failed: " + e.getMessage()); // 검증 실패 시 에러 메시지 출력
+            return false; // **유효하지 않은 토큰 처리**
+        }
+    }
+    
+    public Claims getClaimFromRefreshToken(String refreshToken) {
+    	try {
+            return Jwts.parserBuilder() // JWT 파서 빌더 생성
+                       .setSigningKey(secretKey) // 서명 검증에 사용할 키 설정
+                       .build() // 파서 빌드
+                       .parseClaimsJws(refreshToken) // JWT 파싱
+                       .getBody(); // **JWT의 Payload에서 클레임 추출**
+        } catch (Exception e) {
+            System.err.println("Failed to extract claims from token: " + e.getMessage()); // 클레임 추출 실패 시 에러 메시지 출력
+            return null; // **비정상적인 토큰에 대한 처리**
+        }
     }
 }


### PR DESCRIPTION
1. PasswordEncrytionUtil 과 Join 서비스 연결을 통한 비밀번호 암호화
2. /auth/refresh 엔드 포인트를 통한 토큰 재발급

[클라이언트] -- (Access Token) --> [API Gateway] --(유효성 검사 실패)--> 401 반환
[클라이언트] --(Refresh Token)--> [인증 서버(Auth)] --(재발급)--> [클라이언트]
[클라이언트] --(새 Access Token)--> [API Gateway] --> [Backend Service]
해당 순서가 바람직함